### PR TITLE
test: Disable RSpec monkey patching

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/spec/authentication_spec.rb
+++ b/spec/authentication_spec.rb
@@ -1,7 +1,6 @@
-require "spec_helper"
 require "autho/authentication"
 
-describe Autho::Authentication do
+RSpec.describe Autho::Authentication do
   describe "#user" do
     let(:finder) { double }
     let(:user) { double(password_digest: digest("sesame")) }

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -1,7 +1,6 @@
-require "spec_helper"
 require "autho/session"
 
-describe Autho::Session do
+RSpec.describe Autho::Session do
 
   describe "#user" do
     let(:finder) { double }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.disable_monkey_patching!
+end


### PR DESCRIPTION
This PR tells RSpec not to add the "monkey patches onto Object etc".

And configure RSpec to always load the spec helper.

